### PR TITLE
feat(leaderboard): add leaderboard endpoint

### DIFF
--- a/src/main/java/api/educai/controllers/ClassroomController.java
+++ b/src/main/java/api/educai/controllers/ClassroomController.java
@@ -91,6 +91,13 @@ public class ClassroomController {
                 .body(reportBytes);
     }
 
+    @Operation(summary = "Retorna o placar da leaderboard com alunos ordenados de forma decrescente baseado na pontuação")
+    @GetMapping(value = "/{classroomId}/leaderboard")
+    public ResponseEntity<List<UserScoreDTO>> getLeaderBoard(@PathVariable ObjectId classroomId) {
+        List<UserScoreDTO> leaderBoard = classroomService.getLeaderBoard(classroomId);
+        return leaderBoard.isEmpty() ? status(204).build() : status(200).body(leaderBoard);
+    }
+
     @Operation(summary = "Deleta uma sala de aula")
     @DeleteMapping("/{id}")
     @Secured("ROLE_TEACHER")

--- a/src/main/java/api/educai/dto/UserScoreDTO.java
+++ b/src/main/java/api/educai/dto/UserScoreDTO.java
@@ -1,0 +1,14 @@
+package api.educai.dto;
+
+import lombok.Getter;
+import org.bson.types.ObjectId;
+
+@Getter
+public class UserScoreDTO {
+
+    private String id;
+    private String name;
+    private Integer score;
+    private String profilePicture;
+
+}

--- a/src/main/java/api/educai/entities/User.java
+++ b/src/main/java/api/educai/entities/User.java
@@ -34,6 +34,7 @@ public class User {
     @DocumentReference
     private List<Classroom> classrooms = new ArrayList<>();
     private Integer score;
+    private String profilePicture;
 
     public User(String name, String email, String password, Role role) {
         this.name = name;

--- a/src/main/java/api/educai/repositories/UserRespository.java
+++ b/src/main/java/api/educai/repositories/UserRespository.java
@@ -1,10 +1,13 @@
 package api.educai.repositories;
 
 import api.educai.entities.User;
+import api.educai.enums.Role;
 import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.Update;
+
+import java.util.List;
 
 public interface UserRespository extends MongoRepository <User, Long> {
     boolean existsByEmail(String email);
@@ -20,4 +23,8 @@ public interface UserRespository extends MongoRepository <User, Long> {
     @Query("{'id': ?0}")
     @Update("{'$push': { 'classrooms': ?1 }}'")
     void addClassroom(ObjectId id, ObjectId classroomId);
+
+    List<User> findByRoleAndClassroomsIdOrderByScoreDesc(Role role, ObjectId classroomId);
+
+
 }

--- a/src/main/java/api/educai/services/ClassroomService.java
+++ b/src/main/java/api/educai/services/ClassroomService.java
@@ -11,6 +11,8 @@ import api.educai.utils.CSVGenerator;
 import api.educai.utils.PasswordGenerator;
 import api.educai.utils.email.EmailService;
 import org.bson.types.ObjectId;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.TypeToken;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
@@ -29,6 +31,8 @@ public class ClassroomService {
 
     @Autowired
     private UserService userService;
+    @Autowired
+    private ModelMapper mapper;
 
     public ClassroomInfoDTO createClassroom(Classroom classroom, ObjectId ownerId) {
         User user = userService.getUserById(ownerId);
@@ -163,5 +167,12 @@ public class ClassroomService {
         classroomRepository.save(classroom);
 
         return new ClassroomInfoDTO(classroom);
+    }
+
+    public List<UserScoreDTO> getLeaderBoard(ObjectId classroomId) {
+
+        List<User> usersScore = userService.getUsersScore(classroomId);
+        return mapper.map(usersScore, new TypeToken<List<UserScoreDTO>>(){}.getType());
+
     }
 }

--- a/src/main/java/api/educai/services/UserService.java
+++ b/src/main/java/api/educai/services/UserService.java
@@ -176,4 +176,8 @@ public class UserService {
         user.incrementScore(score);
         userRespository.save(user);
     }
+
+    public List<User> getUsersScore(ObjectId classroomId) {
+        return userRespository.findByRoleAndClassroomsIdOrderByScoreDesc(Role.STUDENT, classroomId);
+    }
 }


### PR DESCRIPTION
## Objetivo

Criação de endpoint para buscar pontuação de alunos por turma.

## Implementação

Criação de novo endpoint e classes para busca das informações.

## Screenshots

![image](https://github.com/educ-ai-org/educai-api/assets/79910007/ad45bcf8-8560-4628-b66c-386537404699)

Exemplo de resultado da request


<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit dcbb969a9314c4a16684d14ffade344dd1cf781d  | 
|--------|

### Summary:
This PR adds a new endpoint to fetch a classroom's leaderboard, sorted by student scores, along with necessary backend updates.

**Key points**:
- Added `getLeaderBoard` endpoint in `ClassroomController`.
- Introduced `UserScoreDTO` for leaderboard data transfer.
- Updated `User` entity with `profilePicture`.
- Added query in `UserRepository` to fetch students by score.
- Implemented score retrieval in `UserService`.
- Added mapping in `ClassroomService` to convert entities to DTOs.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
