### PR TITLE
Fix/create post

### DIFF
--- a/src/main/java/api/educai/controllers/PostController.java
+++ b/src/main/java/api/educai/controllers/PostController.java
@@ -11,11 +11,14 @@ import jakarta.validation.Valid;
 import org.bson.types.ObjectId;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -29,9 +32,13 @@ public class PostController {
 
     @Secured("ROLE_TEACHER")
     @Operation(summary = "Cria um post")
-    @PostMapping
-    public ResponseEntity<Post> createPost(@RequestBody @Valid NewPostDTO post, MultipartFile file){
-        return ResponseEntity.status(201).body(postService.createPost(post, file));
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Post> createPost( @RequestParam("file") MultipartFile file,
+                                            @RequestParam("title") String title,
+                                            @RequestParam(value = "description", required = false) String description,
+                                            @RequestParam(value = "datePosting") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate datePosting,
+                                            @RequestParam(value = "classroomId") String classroomId){
+        return ResponseEntity.status(201).body(postService.createPost(new NewPostDTO(title, description, datePosting, classroomId), file));
 
     }
 

--- a/src/main/java/api/educai/dto/NewPostDTO.java
+++ b/src/main/java/api/educai/dto/NewPostDTO.java
@@ -1,6 +1,7 @@
 package api.educai.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
@@ -11,10 +12,17 @@ public class NewPostDTO {
     @NotBlank
     @Size(max = 100)
     private String title;
-    @NotBlank
     @Size(max = 100)
     private String description;
-    private String url;
+    @NotNull
     private LocalDate datePosting;
+    @NotBlank
     private String classroomId;
+
+    public NewPostDTO(String title, String description, LocalDate datePosting, String classroomId) {
+        this.title = title;
+        this.description = description;
+        this.datePosting = datePosting;
+        this.classroomId = classroomId;
+    }
 }


### PR DESCRIPTION
## Objetivo

Possibilitar o envio de documento e detalhes do Post no endpoint de criar Post.

## Implementação

Alteração no DTO e nos parâmetros da requisição.

## Screenshots

![image](https://github.com/educ-ai-org/educai-api/assets/79910007/09c6488d-4200-4af0-9646-f3746b26f77d)

Exemplo de requisição