### PR TITLE
feat: generate sas token for azure storage

### DIFF
--- a/src/main/java/api/educai/controllers/AzureStorageController.java
+++ b/src/main/java/api/educai/controllers/AzureStorageController.java
@@ -1,0 +1,24 @@
+package api.educai.controllers;
+
+import api.educai.services.AzureBlobService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("file")
+@Tag(name = "Azure Storage", description = "API para serviços relacionados ao armazenamento de arquivos.")
+public class AzureStorageController {
+
+    @Autowired
+    private AzureBlobService azureStorageService;
+
+    @GetMapping("/sas-token")
+    public String getSasToken(@RequestParam String fileName) {
+        return azureStorageService.generateSasToken(fileName);
+    }
+
+}


### PR DESCRIPTION
## Objetivo

Endpoint para gerar Token SAS para storage da Azure (válido por 1 hora)

## Implementação

Criação de método e endpoint para gerar SAS Token

## Screenshots

![image](https://github.com/user-attachments/assets/4661c134-43a4-43d3-8d0b-02d9ee49aca7)

Exemplo de resultado da requisição

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds endpoint and service method to generate 1-hour read-only SAS tokens for Azure Storage.
> 
>   - **Feature**:
>     - Adds `getSasToken()` method in `AzureBlobService.java` to generate SAS tokens for Azure Storage with read permissions, valid for 1 hour.
>     - Introduces `AzureStorageController.java` with endpoint `/file/sas-token` to expose SAS token generation via HTTP GET request.
>   - **Configuration**:
>     - Utilizes `connectionString` and `containerName` from application properties for Azure Storage connection in `AzureBlobService.java`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=educ-ai-org%2Feducai-api&utm_source=github&utm_medium=referral)<sup> for 80e1eb85fbd174235154c08af4eecbee073ddc0e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->