### PR TITLE
feat: use generated token for getUrl

### DIFF
--- a/src/main/java/api/educai/services/AzureBlobService.java
+++ b/src/main/java/api/educai/services/AzureBlobService.java
@@ -32,9 +32,6 @@ public class AzureBlobService {
     @Value("${azure.storage.url}")
     private String storageUrl;
 
-    @Value("${azure.storage.blob-token}")
-    private String blobToken;
-
     @Value("${azure.storage.connection.string}")
     private String connectionString;
 
@@ -72,7 +69,7 @@ public class AzureBlobService {
 
     public String getBlobUrl(String fileName){
         BlobClient blob = blobContainerClient.getBlobClient(fileName);
-        return blob.getBlobUrl() + "?%s".formatted(blobToken);
+        return blob.getBlobUrl() + "?%s".formatted(generateSasToken(fileName));
     }
 
     public byte[] download(String fileName)


### PR DESCRIPTION
## Objetivo

Utilizar o método de geração de token para obter a URL do arquivo

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `getBlobUrl` in `AzureBlobService.java` now generates a SAS token for blob URLs, removing the need for a static token.
> 
>   - **Behavior**:
>     - `getBlobUrl` in `AzureBlobService.java` now uses `generateSasToken` to create a SAS token for blob URLs instead of using a static `blobToken`.
>   - **Configuration**:
>     - Removed `blobToken` configuration from `AzureBlobService.java`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=educ-ai-org%2Feducai-api&utm_source=github&utm_medium=referral)<sup> for 7088742ce8e64f18d625f180d12ddcb169edadbd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->