### PR TITLE
Feat/get users profile pictures

### DIFF
--- a/src/main/java/api/educai/controllers/ClassroomController.java
+++ b/src/main/java/api/educai/controllers/ClassroomController.java
@@ -8,6 +8,7 @@ import api.educai.dto.classwork.ClassworkUserDTO;
 import api.educai.dto.post.PostDTO;
 import api.educai.dto.user.ReportDTO;
 import api.educai.dto.user.UserDTO;
+import api.educai.dto.user.UserPictureDTO;
 import api.educai.entities.Classroom;
 import api.educai.entities.Post;
 import api.educai.services.ClassroomService;
@@ -116,6 +117,12 @@ public class ClassroomController {
     public ResponseEntity<List<UserScoreDTO>> getLeaderBoard(@PathVariable ObjectId classroomId) {
         List<UserScoreDTO> leaderBoard = classroomService.getLeaderBoard(classroomId);
         return leaderBoard.isEmpty() ? status(204).build() : status(200).body(leaderBoard);
+    }
+
+    @GetMapping("/{classroomId}/profile-pictures")
+    public ResponseEntity<List<UserPictureDTO>> getParticipantsPictures(@PathVariable ObjectId classroomId) {
+        List<UserPictureDTO> userPictures = classroomService.getParticipantsPictures(classroomId);
+        return userPictures.isEmpty() ? status(204).build() : status(200).body(userPictures);
     }
 
     @Operation(summary = "Deleta uma sala de aula")

--- a/src/main/java/api/educai/dto/user/UserPictureDTO.java
+++ b/src/main/java/api/educai/dto/user/UserPictureDTO.java
@@ -1,10 +1,9 @@
 package api.educai.dto.user;
 
 import api.educai.entities.User;
+import api.educai.services.AzureBlobService;
 import lombok.Data;
 import org.bson.types.ObjectId;
-
-import static api.educai.services.UserService.getFileName;
 
 @Data
 public class UserPictureDTO {
@@ -14,7 +13,7 @@ public class UserPictureDTO {
 
     public UserPictureDTO(User user) {
         this.id = user.getId();
-        this.profilePicture = getFileName(user.getProfilePicture());
+        this.profilePicture = user.getProfilePicture() + "?" + AzureBlobService.getGlobalToken();
     }
 
 }

--- a/src/main/java/api/educai/dto/user/UserPictureDTO.java
+++ b/src/main/java/api/educai/dto/user/UserPictureDTO.java
@@ -1,0 +1,20 @@
+package api.educai.dto.user;
+
+import api.educai.entities.User;
+import lombok.Data;
+import org.bson.types.ObjectId;
+
+import static api.educai.services.UserService.getFileName;
+
+@Data
+public class UserPictureDTO {
+
+    private ObjectId id;
+    private String profilePicture;
+
+    public UserPictureDTO(User user) {
+        this.id = user.getId();
+        this.profilePicture = getFileName(user.getProfilePicture());
+    }
+
+}

--- a/src/main/java/api/educai/services/AzureBlobService.java
+++ b/src/main/java/api/educai/services/AzureBlobService.java
@@ -12,6 +12,7 @@ import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
 import com.azure.storage.blob.sas.BlobSasPermission;
 import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
+import lombok.Getter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatusCode;
@@ -37,6 +38,10 @@ public class AzureBlobService {
 
     @Value("${azure.storage.container.name}")
     private String containerName;
+
+    @Getter
+    @Value("${azure.storage.blob-token}")
+    private static String globalToken;
 
     public String upload(MultipartFile file)
             throws IOException {

--- a/src/main/java/api/educai/services/ClassroomService.java
+++ b/src/main/java/api/educai/services/ClassroomService.java
@@ -10,11 +10,11 @@ import api.educai.dto.post.PostDTO;
 import api.educai.dto.user.NewStudentEmailDTO;
 import api.educai.dto.user.ReportDTO;
 import api.educai.dto.user.UserDTO;
+import api.educai.dto.user.UserPictureDTO;
 import api.educai.entities.Answer;
 import api.educai.entities.Classroom;
 import api.educai.entities.Post;
 import api.educai.entities.User;
-import api.educai.repositories.AnswerRepository;
 import api.educai.repositories.ClassroomRepository;
 import api.educai.repositories.UserRespository;
 import api.educai.utils.CSVGenerator;
@@ -238,6 +238,14 @@ public class ClassroomService {
 
         userRespository.save(user);
         classroomRepository.save(classroom);
+    }
+
+    public List<UserPictureDTO> getParticipantsPictures(ObjectId classroomId) {
+        Classroom classroom = getClassroomById(classroomId);
+        return classroom.getParticipants().stream()
+                .filter(user -> user.getProfilePicture() != null)
+                .map(UserPictureDTO::new)
+                .toList();
     }
 
 }

--- a/src/main/java/api/educai/services/UserService.java
+++ b/src/main/java/api/educai/services/UserService.java
@@ -204,17 +204,19 @@ public class UserService {
     public byte[] getProfilePicture(ObjectId userId) throws URISyntaxException {
         User user = getUserById(userId);
         String path = user.getProfilePicture();
-        String[] parts = path.split("/");
-        String fileName = parts[parts.length - 1];
+        String fileName = getFileName(path);
         return azureBlobService.download(fileName);
     }
 
     public String getProfilePictureUrl(ObjectId userId) throws URISyntaxException {
         User user = getUserById(userId);
         String path = user.getProfilePicture();
+        return azureBlobService.getBlobUrl(getFileName(path));
+    }
+
+    public static String getFileName(String path) {
         String[] parts = path.split("/");
-        String fileName = parts[parts.length - 1];
-        return azureBlobService.getBlobUrl(fileName);
+        return parts[parts.length - 1];
     }
 
 }


### PR DESCRIPTION
## Objetivo

Retornar URLs de imagens dos participantes da turma

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds endpoint to retrieve classroom participants' profile picture URLs with a new DTO and service support.
> 
>   - **Behavior**:
>     - Adds `getParticipantsPictures()` endpoint in `ClassroomController` to return profile picture URLs for classroom participants.
>     - Returns 204 status if no pictures are available.
>   - **DTOs**:
>     - Introduces `UserPictureDTO` to encapsulate user ID and profile picture URL with a global token.
>   - **Services**:
>     - Adds `getParticipantsPictures()` in `ClassroomService` to fetch and filter users with profile pictures.
>     - Adds `getGlobalToken` in `AzureBlobService` to retrieve a static blob token.
>   - **Misc**:
>     - Refactors `getFileName()` in `UserService` to be a static method for reuse.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=educ-ai-org%2Feducai-api&utm_source=github&utm_medium=referral)<sup> for 1dbc6a2a64eda63663dcf5c36d0c29097f2eb390. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->