### PR TITLE
feat: return user id as string

### DIFF
--- a/src/main/java/api/educai/dto/user/UserPictureDTO.java
+++ b/src/main/java/api/educai/dto/user/UserPictureDTO.java
@@ -3,16 +3,15 @@ package api.educai.dto.user;
 import api.educai.entities.User;
 import api.educai.services.AzureBlobService;
 import lombok.Data;
-import org.bson.types.ObjectId;
 
 @Data
 public class UserPictureDTO {
 
-    private ObjectId id;
+    private String id;
     private String profilePicture;
 
     public UserPictureDTO(User user) {
-        this.id = user.getId();
+        this.id = user.getId().toString();
         this.profilePicture = user.getProfilePicture() + "?" + AzureBlobService.getGlobalToken();
     }
 


### PR DESCRIPTION
## Objetivo

Retornar ID de usuário como String no endpoint para recuperar a imagem de perfil

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `id` type from `ObjectId` to `String` in `UserPictureDTO` to return user ID as a string.
> 
>   - **Behavior**:
>     - Change `id` type from `ObjectId` to `String` in `UserPictureDTO`.
>     - Convert `user.getId()` to `String` in `UserPictureDTO` constructor.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=educ-ai-org%2Feducai-api&utm_source=github&utm_medium=referral)<sup> for 3e75d909b47c7e545640ebd1a775126ed51030fc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->